### PR TITLE
Use HTTPS for WASM spec submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "spec"]
 	path = spec
-	url = git@github.com:WebAssembly/spec.git
+	url = https://github.com/WebAssembly/spec.git


### PR DESCRIPTION
There's an unfortunate interaction with Poetry when installing `py-wasm` directly from GitHub because of the SSH-protocol submodule. This PR just points the module at the HTTPS equivalent so that Poetry is able to resolve the dependency properly.