### PR TITLE
Wrap instructions with position info for tracing

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.0
+current_version = 0.3.0
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<stage>[^.]*)\.(?P<devnum>\d+))?

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ extras_require['dev'] = (
 setup(
     name='py-wasm',
     # *IMPORTANT*: Don't manually change the version here. Use `make bump`, as described in readme
-    version='0.2.0',
+    version='0.3.0',
     description="""py-wasm: A python implementation of the web assembly interpreter""",
     author='Jason Carver',
     author_email='ethcalibur+pip@gmail.com',

--- a/tests/binary/data/instrs.wat
+++ b/tests/binary/data/instrs.wat
@@ -5,6 +5,7 @@
   (global (mut i32) (i32.const 0))
   (func (param i32 i64) (local f64))
   (func $f)
+  (elem func $f)
   (global funcref (ref.func $f))
   (func (local i32)
         ;; `unreachable` and `drop` are inserted as needed to

--- a/wasm/instructions/__init__.py
+++ b/wasm/instructions/__init__.py
@@ -2,6 +2,8 @@ from typing import (
     Union,
 )
 
+from .base import InstructionWithPos
+
 from .table import (
     ElemDrop,
     TableCopy,
@@ -67,6 +69,7 @@ from .variable import (  # noqa: F401
 
 Instruction = Union[
     BaseInstruction,
+    InstructionWithPos,
     I32Const, I64Const,
     F32Const, F64Const,
     UnOp,

--- a/wasm/instructions/base.py
+++ b/wasm/instructions/base.py
@@ -1,6 +1,7 @@
 from abc import ABC
 from typing import (
     Any,
+    NamedTuple,
     Type,
     TypeVar,
 )
@@ -31,6 +32,15 @@ def register(cls: Type[TInstruction]) -> Type[TInstruction]:
     """
     BaseInstruction.register(cls)
     return cls
+
+@register
+class InstructionWithPos(NamedTuple):
+    pos: tuple[int, int]
+    instruction: BaseInstruction
+
+    @property
+    def opcode(self) -> BinaryOpcode:
+        return self.instruction.opcode
 
 
 class SimpleOp(Interned):

--- a/wasm/parsers/control.py
+++ b/wasm/parsers/control.py
@@ -27,6 +27,7 @@ from wasm.instructions import (
     Return,
     Unreachable,
 )
+from wasm.instructions.base import InstructionWithPos
 from wasm.opcodes import (
     BinaryOpcode,
 )
@@ -102,10 +103,14 @@ def parse_inner_block_instructions(stream: IO[bytes]) -> Iterable[BaseInstructio
     from wasm.parsers.instructions import parse_instruction  # noqa: F401
 
     while True:
-        instruction = cast(BaseInstruction, parse_instruction(stream))
-        yield instruction
+        instruction = parse_instruction(stream)
+        base_instruction = cast(BaseInstruction, instruction)
+        yield base_instruction
         if isinstance(instruction, End):
             break
+        if isinstance(instruction, InstructionWithPos):
+            if isinstance(instruction.instruction, End):
+                break
 
 
 def parse_loop_instruction(stream: IO[bytes]) -> Loop:

--- a/wasm/parsers/instructions.py
+++ b/wasm/parsers/instructions.py
@@ -5,6 +5,7 @@ from wasm.exceptions import (
 )
 from wasm.instructions import (
     Instruction,
+    InstructionWithPos,
 )
 from wasm.opcodes import (
     BinaryOpcode,
@@ -31,6 +32,20 @@ from .variable import (
 
 
 def parse_instruction(stream: IO[bytes]) -> Instruction:
+    """
+    Parse a single instruction with it's position.
+    """
+
+    pos_start = stream.tell()
+
+    instruction = parse_instruction_without_pos(stream)
+
+    pos_end = stream.tell()
+
+    return InstructionWithPos((pos_start, pos_end), instruction)
+    
+
+def parse_instruction_without_pos(stream: IO[bytes]) -> Instruction:
     """
     Parse a single instruction.
     """


### PR DESCRIPTION
This PR introduces a helper instruction wrapper to attach source position metadata to parsed Wasm instructions:

```python
class InstructionWithPos(NamedTuple):
    pos: tuple[int, int]
    instruction: BaseInstruction

    @property
    def opcode(self) -> BinaryOpcode:
        return self.instruction.opcode
```

### Motivation

The K Wasm semantics does not carry position information for instructions. However, the debugger will rely on execution traces that can be mapped back to the original binary. This wrapper allows us to preserve byte offsets during parsing without affecting semantics.

### Changes

* Add `InstrWithPos` wrapper type
* Update `parse_instruction` to return `InstructionWithPos`, wrapping parsed instructions with `(pos_start, pos_end)` byte offsets
* Ensure existing instruction structure remains unchanged.

### Notes

* This is a non-semantic annotation used only for tracing/debugging
* The K semantics is expected to unwrap this constructor during execution, so it will have no effect on behavior.

### Follow-ups

* Add corresponding support in `wasm-semantics`:

```k
syntax Instr ::= #instrWithPos(inner: Instr, posStart: Int, posEnd: Int)
rule <instrs> #instrWithPos(I, _, _) => I ... </instrs>
```

* Use this metadata in trace generation for debugger integration


**Note**: I have already implemented and tested the corresponding changes in wasm-semantics locally. I will open a separate PR there after this one is merged.
