### PR TITLE
Fix If/Else parser

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.0
+current_version = 0.3.1
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<stage>[^.]*)\.(?P<devnum>\d+))?

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ extras_require['dev'] = (
 setup(
     name='py-wasm',
     # *IMPORTANT*: Don't manually change the version here. Use `make bump`, as described in readme
-    version='0.3.0',
+    version='0.3.1',
     description="""py-wasm: A python implementation of the web assembly interpreter""",
     author='Jason Carver',
     author_email='ethcalibur+pip@gmail.com',

--- a/wasm/parsers/control.py
+++ b/wasm/parsers/control.py
@@ -106,11 +106,8 @@ def parse_inner_block_instructions(stream: IO[bytes]) -> Iterable[BaseInstructio
         instruction = parse_instruction(stream)
         base_instruction = cast(BaseInstruction, instruction)
         yield base_instruction
-        if isinstance(instruction, End):
+        if instruction.opcode == BinaryOpcode.END:
             break
-        if isinstance(instruction, InstructionWithPos):
-            if isinstance(instruction.instruction, End):
-                break
 
 
 def parse_loop_instruction(stream: IO[bytes]) -> Loop:
@@ -130,7 +127,7 @@ def parse_if_instruction(stream: IO[bytes]) -> If:
     result_type = parse_blocktype(stream)
 
     all_instructions = parse_inner_block_instructions(stream)
-    partitioned_instructions = tuple(partitionby(lambda v: isinstance(v, Else), all_instructions))
+    partitioned_instructions = tuple(partitionby(lambda v: v.opcode == BinaryOpcode.ELSE, all_instructions))
 
     if len(partitioned_instructions) == 1:  # if without else
         if_instructions = all_instructions


### PR DESCRIPTION
A previous change introduced the `InstructionWithPos` auxiliary wrapper instruction. This exposed an issue in the If/Else parser logic where the `isinstance(v, Else)` used for marking the beginning of the else block would fail for wrapped instructions. As a result, Else instructions were not detected correctly and the parser would append the else blocks to the then blocks.

This PR fixes `parse_if_instruction` by switching Else detection to opcode-based matching (`v.opcode == BinaryOpcode.Else`), allowing the parser to correctly handle both wrapped and unwrapped instructions.

As part of this cleanup, `parse_inner_block_instructions` is also refactored to use the same opcode-based approach instead of instance checks.
